### PR TITLE
Fix vec0 table schema for memo paragraphs

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -66,10 +66,10 @@ db.exec(`
                 PRIMARY key (memo_id_1, memo_id_2)
         );
         CREATE VIRTUAL TABLE IF NOT EXISTS memo_paragraphs USING vec0(
+                id INTEGER PRIMARY KEY,
                 memo_id INTEGER NOT NULL,
                 paragraph_index INTEGER NOT NULL,
-                embedding FLOAT[512],
-                PRIMARY KEY (memo_id, paragraph_index)
+                embedding FLOAT[512]
         );
 `)
 


### PR DESCRIPTION
## Summary
- remove unsupported composite primary key in memo_paragraphs vec0 table
- add id column as primary key so vec0 table loads correctly

## Testing
- `npm start` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68c61e18a9e083289fb750c75830285a