### PR TITLE
Handle memo IDs as BigInt for sqlite-vec

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -75,18 +75,18 @@ db.exec(`
 
 // memosにベクトルを保存
 function updateEmbedding(id, json) {
-	db.prepare(
-		`UPDATE memos
-		SET embedding = :json
-		WHERE id = :id`,
-	).run({ id, json })
+        db.prepare(
+                `UPDATE memos
+                SET embedding = :json
+                WHERE id = :id`,
+        ).run({ id: BigInt(id), json })
 }
 
 // 新しいメモのidのmemo_similaritiesを削除
 function deleteSimilaritiesFor(id) {
-	db.prepare(
-		`DELETE FROM memo_similarities WHERE memo_id_1 = :id OR memo_id_2 = :id`
-	).run({ id });
+        db.prepare(
+                `DELETE FROM memo_similarities WHERE memo_id_1 = :id OR memo_id_2 = :id`
+        ).run({ id: BigInt(id) });
 }
 
 // 新しいメモと既存のすべてのメモとの距離を計算、memo_similaritiesに保存
@@ -105,7 +105,7 @@ function insertSimilaritiesFor(id) {
                 HAVING similarity_score >= :threshold
                 ORDER BY similarity_score DESC
                 LIMIT :limit
-        `).run({ id, threshold: SIMILARITY_THRESHOLD, limit: SIMILARITY_LIMIT })
+        `).run({ id: BigInt(id), threshold: SIMILARITY_THRESHOLD, limit: SIMILARITY_LIMIT })
 }
 
 const jstDate = (d = new Date()) =>
@@ -129,18 +129,18 @@ async function calcSimilarities(id, content) {
         tensor.dispose();
 
         // 段落ごとのベクトルを保存
-        const memoId = Number.parseInt(id, 10);
+        const memoId = BigInt(Number.parseInt(id, 10));
         db.prepare(`DELETE FROM memo_paragraphs WHERE memo_id = ?`).run(memoId);
         const insertPar = db.prepare(`INSERT INTO memo_paragraphs (memo_id, paragraph_index, embedding) VALUES (?, ?, ?)`);
-        vecs.forEach((v, i) => insertPar.run(memoId, i, JSON.stringify(v)));
+        vecs.forEach((v, i) => insertPar.run(memoId, BigInt(i), JSON.stringify(v)));
 
         // メモ全体のベクトルは段落ベクトルの平均とする
         const avgVec = vecs[0].map((_, dim) => vecs.reduce((sum, v) => sum + v[dim], 0) / vecs.length);
         const jsonVec = JSON.stringify(avgVec);
 
-        updateEmbedding(id, jsonVec);
-        deleteSimilaritiesFor(id);
-        insertSimilaritiesFor(id);
+        updateEmbedding(memoId, jsonVec);
+        deleteSimilaritiesFor(memoId);
+        insertSimilaritiesFor(memoId);
 }
 
 // listen開始


### PR DESCRIPTION
## Summary
- convert memo_id and paragraph_index bindings to BigInt when writing to vec0 tables
- update embedding and similarity helpers to use BigInt ids

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c630b2dc1c83289d614ccfbc41a95f