### PR TITLE
Handle BigInt memo IDs and scale graph link distance

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -75,18 +75,18 @@ db.exec(`
 
 // memosにベクトルを保存
 function updateEmbedding(id, json) {
-	db.prepare(
-		`UPDATE memos
-		SET embedding = :json
-		WHERE id = :id`,
-	).run({ id, json })
+        db.prepare(
+                `UPDATE memos
+                SET embedding = :json
+                WHERE id = :id`,
+        ).run({ id: BigInt(id), json })
 }
 
 // 新しいメモのidのmemo_similaritiesを削除
 function deleteSimilaritiesFor(id) {
-	db.prepare(
-		`DELETE FROM memo_similarities WHERE memo_id_1 = :id OR memo_id_2 = :id`
-	).run({ id });
+        db.prepare(
+                `DELETE FROM memo_similarities WHERE memo_id_1 = :id OR memo_id_2 = :id`
+        ).run({ id: BigInt(id) });
 }
 
 // 新しいメモと既存のすべてのメモとの距離を計算、memo_similaritiesに保存
@@ -105,7 +105,7 @@ function insertSimilaritiesFor(id) {
                 HAVING similarity_score >= :threshold
                 ORDER BY similarity_score DESC
                 LIMIT :limit
-        `).run({ id, threshold: SIMILARITY_THRESHOLD, limit: SIMILARITY_LIMIT })
+        `).run({ id: BigInt(id), threshold: SIMILARITY_THRESHOLD, limit: SIMILARITY_LIMIT })
 }
 
 const jstDate = (d = new Date()) =>
@@ -129,18 +129,18 @@ async function calcSimilarities(id, content) {
         tensor.dispose();
 
         // 段落ごとのベクトルを保存
-        const memoId = Number.parseInt(id, 10);
+        const memoId = BigInt(Number.parseInt(id, 10));
         db.prepare(`DELETE FROM memo_paragraphs WHERE memo_id = ?`).run(memoId);
         const insertPar = db.prepare(`INSERT INTO memo_paragraphs (memo_id, paragraph_index, embedding) VALUES (?, ?, ?)`);
-        vecs.forEach((v, i) => insertPar.run(memoId, i, JSON.stringify(v)));
+        vecs.forEach((v, i) => insertPar.run(memoId, BigInt(i), JSON.stringify(v)));
 
         // メモ全体のベクトルは段落ベクトルの平均とする
         const avgVec = vecs[0].map((_, dim) => vecs.reduce((sum, v) => sum + v[dim], 0) / vecs.length);
         const jsonVec = JSON.stringify(avgVec);
 
-        updateEmbedding(id, jsonVec);
-        deleteSimilaritiesFor(id);
-        insertSimilaritiesFor(id);
+        updateEmbedding(memoId, jsonVec);
+        deleteSimilaritiesFor(memoId);
+        insertSimilaritiesFor(memoId);
 }
 
 // listen開始

--- a/frontend/components/GraphCanvas.tsx
+++ b/frontend/components/GraphCanvas.tsx
@@ -10,6 +10,9 @@ import { useRouter } from "next/navigation";
 const NODE_W = 140;
 const NODE_H = 60;
 const NODE_R = Math.hypot(NODE_W / 2, NODE_H / 2);
+const SIMILARITY_THRESHOLD = parseFloat(
+  process.env.NEXT_PUBLIC_SIMILARITY_THRESHOLD ?? "0.5"
+);
 
 /**
  * 高速 Canvas グラフ（d3-force）
@@ -137,7 +140,18 @@ export default function GraphCanvas({
     const R = NODE_R + 8; // margin
     const sim = d3
       .forceSimulation(nodes as any)
-      .force("link", d3.forceLink(links as any).id((d: any) => d.id).distance(250).strength(0.4))
+      .force(
+        "link",
+        d3
+          .forceLink(links as any)
+          .id((d: any) => d.id)
+          .distance((d: any) => {
+            const t = SIMILARITY_THRESHOLD;
+            const s = Math.max(Math.min(d.score ?? t, 1), t);
+            return 200 + ((1 - s) / (1 - t)) * 400;
+          })
+          .strength(0.4)
+      )
       .force("charge", d3.forceManyBody().strength(-120))
       .force("center", d3.forceCenter(0, 0))
       .force("collide", d3.forceCollide(R))


### PR DESCRIPTION
## Summary
- convert memo_id and paragraph_index bindings to BigInt when writing to vec0 tables
- update embedding and similarity helpers to use BigInt ids
- map similarity scores to link distances so identical notes are 200 units apart and threshold links 600

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c630b2dc1c83289d614ccfbc41a95f